### PR TITLE
feat: Kanban board view with drag-and-drop [TD-0017]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@neondatabase/serverless": "^1.0.2",
         "clsx": "^2.1.1",
         "dotenv": "^17.3.1",
@@ -86,6 +89,59 @@
       "license": "ISC",
       "dependencies": {
         "@auth/core": "0.41.1"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -578,6 +634,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -595,6 +652,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -612,6 +670,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -629,6 +688,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -646,6 +706,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -663,6 +724,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -680,6 +742,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -697,6 +760,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -714,6 +778,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -731,6 +796,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -748,6 +814,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -765,6 +832,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -782,6 +850,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -799,6 +868,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -816,6 +886,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -833,6 +904,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -850,6 +922,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -867,6 +940,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -884,6 +958,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -901,6 +976,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -918,6 +994,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -935,6 +1012,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -952,6 +1030,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -969,6 +1048,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -986,6 +1066,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1003,6 +1084,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1483,7 +1565,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -1886,7 +1967,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1947,7 +2027,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2606,7 +2685,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4341,7 +4419,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4511,7 +4588,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5891,7 +5967,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7112,7 +7187,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7300,7 +7374,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7373,7 +7446,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7386,7 +7458,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8397,7 +8468,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8577,7 +8647,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8678,7 +8747,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@neondatabase/serverless": "^1.0.2",
     "clsx": "^2.1.1",
     "dotenv": "^17.3.1",

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { LayoutDashboard, Map, ListTodo, Settings, Users, Menu, X, LogOut, LifeBuoy } from "lucide-react"
+import { LayoutDashboard, Map, ListTodo, Settings, Users, Menu, X, LogOut, LifeBuoy, Kanban } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/use-auth"
 
@@ -27,6 +27,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         { href: `/dashboard/workspaces/${workspaceId}`, label: "Overview", icon: LayoutDashboard },
         { href: `/dashboard/workspaces/${workspaceId}/roadmap`, label: "Roadmap", icon: Map },
         { href: `/dashboard/workspaces/${workspaceId}/work-items`, label: "Work Items", icon: ListTodo },
+        { href: `/dashboard/workspaces/${workspaceId}/work-items/kanban`, label: "Kanban", icon: Kanban },
         { href: `/dashboard/workspaces/${workspaceId}/members`, label: "Members", icon: Users },
         { href: `/dashboard/workspaces/${workspaceId}/settings`, label: "Settings", icon: Settings },
       ]

--- a/src/app/dashboard/workspaces/[workspaceId]/work-items/kanban/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/work-items/kanban/page.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import useSWR from "swr"
+import { Plus, Kanban } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { PageHeader } from "@/components/shared/page-header"
+import { EmptyState } from "@/components/shared/empty-state"
+import { KanbanBoard } from "@/components/work-items/kanban-board"
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+export default function KanbanPage({
+  params,
+}: {
+  params: { workspaceId: string }
+}) {
+  const { workspaceId } = params
+  const router = useRouter()
+
+  const { data: items, isLoading, mutate } = useSWR(
+    `/api/workspaces/${workspaceId}/work-items`,
+    fetcher
+  )
+
+  return (
+    <div>
+      <PageHeader
+        title="Kanban Board"
+        description="Drag and drop items between status columns"
+        actions={
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items`)}
+            >
+              List view
+            </Button>
+            <Button
+              onClick={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items/new`)}
+            >
+              <Plus className="w-4 h-4 mr-1" /> New item
+            </Button>
+          </div>
+        }
+      />
+
+      {isLoading ? (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="min-w-[260px] w-[260px] flex-shrink-0 space-y-2">
+              <Skeleton className="h-9 rounded-t-lg rounded-b-none" />
+              <Skeleton className="h-20" />
+              <Skeleton className="h-16" />
+              <Skeleton className="h-20" />
+            </div>
+          ))}
+        </div>
+      ) : items?.length === 0 ? (
+        <EmptyState
+          icon={<Kanban className="w-12 h-12" />}
+          title="No work items"
+          description="Create your first work item to start tracking product work."
+          actionLabel="New work item"
+          onAction={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items/new`)}
+        />
+      ) : (
+        <KanbanBoard
+          items={items || []}
+          workspaceId={workspaceId}
+          onStatusChange={() => mutate()}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/workspaces/[workspaceId]/work-items/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/work-items/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import useSWR from "swr"
-import { Plus, ListTodo } from "lucide-react"
+import { Plus, ListTodo, Kanban } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Select } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -42,9 +42,17 @@ export default function WorkItemsPage({
         title="Work Items"
         description="All work items in this workspace"
         actions={
-          <Button onClick={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items/new`)}>
-            <Plus className="w-4 h-4 mr-1" /> New item
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items/kanban`)}
+            >
+              <Kanban className="w-4 h-4 mr-1" /> Kanban
+            </Button>
+            <Button onClick={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items/new`)}>
+              <Plus className="w-4 h-4 mr-1" /> New item
+            </Button>
+          </div>
         }
       />
 

--- a/src/components/work-items/kanban-board.tsx
+++ b/src/components/work-items/kanban-board.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  DragStartEvent,
+  DragEndEvent,
+  closestCenter,
+} from "@dnd-kit/core"
+import { KanbanColumn } from "./kanban-column"
+import { KanbanCard, WorkItemCardData } from "./kanban-card"
+import { WORK_ITEM_STATUSES, STATUS_LABELS, WorkItemStatus } from "@/lib/constants"
+import { useToast } from "@/components/ui/toast"
+
+interface KanbanBoardProps {
+  items: WorkItemCardData[]
+  workspaceId: string
+  onStatusChange?: (itemId: string, newStatus: string) => void
+}
+
+// Columns to display on the Kanban board (exclude cancelled from primary view but keep it accessible)
+const KANBAN_COLUMNS: WorkItemStatus[] = ["todo", "in-progress", "in-review", "done", "blocked", "cancelled"]
+
+export function KanbanBoard({ items: initialItems, workspaceId, onStatusChange }: KanbanBoardProps) {
+  const [items, setItems] = useState<WorkItemCardData[]>(initialItems)
+  const [activeItem, setActiveItem] = useState<WorkItemCardData | null>(null)
+  const [updatingIds, setUpdatingIds] = useState<Set<string>>(new Set())
+  const { toast } = useToast()
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 8,
+      },
+    })
+  )
+
+  const getColumnItems = useCallback(
+    (status: string) => items.filter((item) => item.status === status),
+    [items]
+  )
+
+  function handleDragStart(event: DragStartEvent) {
+    const { active } = event
+    const item = items.find((i) => i.id === active.id)
+    if (item) setActiveItem(item)
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    setActiveItem(null)
+
+    if (!over) return
+
+    const draggedItem = items.find((i) => i.id === active.id)
+    if (!draggedItem) return
+
+    const newStatus = over.id as string
+    if (draggedItem.status === newStatus) return
+
+    // Optimistic update
+    const prevItems = items
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === draggedItem.id ? { ...item, status: newStatus } : item
+      )
+    )
+    setUpdatingIds((prev) => new Set(prev).add(draggedItem.id))
+
+    try {
+      const response = await fetch(
+        `/api/workspaces/${workspaceId}/work-items/${draggedItem.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: newStatus }),
+        }
+      )
+
+      if (!response.ok) {
+        throw new Error("Failed to update status")
+      }
+
+      onStatusChange?.(draggedItem.id, newStatus)
+      toast(`Moved to "${STATUS_LABELS[newStatus] || newStatus}"`, { variant: "success" })
+    } catch (err) {
+      // Revert on error
+      setItems(prevItems)
+      toast("Failed to update status. Please try again.", { variant: "error" })
+    } finally {
+      setUpdatingIds((prev) => {
+        const next = new Set(prev)
+        next.delete(draggedItem.id)
+        return next
+      })
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {KANBAN_COLUMNS.map((status) => (
+          <KanbanColumn
+            key={status}
+            status={status}
+            label={STATUS_LABELS[status] || status}
+            items={getColumnItems(status)}
+            workspaceId={workspaceId}
+          />
+        ))}
+      </div>
+
+      <DragOverlay dropAnimation={{ duration: 150, easing: "cubic-bezier(0.18, 0.67, 0.6, 1.22)" }}>
+        {activeItem ? (
+          <KanbanCard item={activeItem} workspaceId={workspaceId} isDragOverlay />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  )
+}

--- a/src/components/work-items/kanban-card.tsx
+++ b/src/components/work-items/kanban-card.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useDraggable } from "@dnd-kit/core"
+import { CSS } from "@dnd-kit/utilities"
+import { useRouter } from "next/navigation"
+import { GripVertical } from "lucide-react"
+import { StatusBadge } from "@/components/shared/status-badge"
+import { PriorityBadge } from "@/components/shared/priority-badge"
+import { TypeIcon } from "@/components/shared/type-icon"
+
+export interface WorkItemCardData {
+  id: string
+  publicId: string
+  title: string
+  type: string
+  status: string
+  priority: string
+}
+
+interface KanbanCardProps {
+  item: WorkItemCardData
+  workspaceId: string
+  isDragOverlay?: boolean
+}
+
+export function KanbanCard({ item, workspaceId, isDragOverlay = false }: KanbanCardProps) {
+  const router = useRouter()
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: item.id,
+    data: { item },
+  })
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`
+        bg-white border rounded-lg p-3 
+        ${isDragging && !isDragOverlay ? "opacity-40 border-blue-300" : "border-gray-200"}
+        ${isDragOverlay ? "shadow-lg rotate-1 cursor-grabbing" : "hover:border-blue-300 hover:shadow-sm"}
+        transition-shadow
+      `}
+    >
+      {/* Drag handle + type icon row */}
+      <div className="flex items-center gap-1 mb-2">
+        <button
+          {...attributes}
+          {...listeners}
+          className="text-gray-300 hover:text-gray-500 cursor-grab active:cursor-grabbing touch-none p-0.5 -ml-1 rounded"
+          aria-label="Drag to reorder"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical className="w-3.5 h-3.5" />
+        </button>
+        <TypeIcon type={item.type} className="w-3.5 h-3.5 text-gray-400" />
+        <span className="text-xs text-gray-400 font-mono">{item.publicId}</span>
+      </div>
+
+      {/* Title — clickable to navigate */}
+      <button
+        onClick={() => router.push(`/dashboard/workspaces/${workspaceId}/work-items/${item.id}`)}
+        className="text-sm font-medium text-gray-900 text-left w-full hover:text-blue-600 transition-colors mb-2 leading-snug"
+      >
+        {item.title}
+      </button>
+
+      {/* Badges */}
+      <div className="flex gap-1.5 flex-wrap">
+        <PriorityBadge priority={item.priority} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/work-items/kanban-column.tsx
+++ b/src/components/work-items/kanban-column.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useDroppable } from "@dnd-kit/core"
+import { KanbanCard, WorkItemCardData } from "./kanban-card"
+
+const columnColors: Record<string, { header: string; bg: string; border: string; dot: string }> = {
+  todo: {
+    header: "text-gray-700",
+    bg: "bg-gray-50",
+    border: "border-gray-200",
+    dot: "bg-gray-400",
+  },
+  "in-progress": {
+    header: "text-blue-700",
+    bg: "bg-blue-50",
+    border: "border-blue-200",
+    dot: "bg-blue-500",
+  },
+  "in-review": {
+    header: "text-purple-700",
+    bg: "bg-purple-50",
+    border: "border-purple-200",
+    dot: "bg-purple-500",
+  },
+  done: {
+    header: "text-green-700",
+    bg: "bg-green-50",
+    border: "border-green-200",
+    dot: "bg-green-500",
+  },
+  blocked: {
+    header: "text-red-700",
+    bg: "bg-red-50",
+    border: "border-red-200",
+    dot: "bg-red-500",
+  },
+  cancelled: {
+    header: "text-gray-500",
+    bg: "bg-gray-50",
+    border: "border-gray-200",
+    dot: "bg-gray-300",
+  },
+}
+
+interface KanbanColumnProps {
+  status: string
+  label: string
+  items: WorkItemCardData[]
+  workspaceId: string
+}
+
+export function KanbanColumn({ status, label, items, workspaceId }: KanbanColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: status })
+  const colors = columnColors[status] || columnColors["todo"]
+
+  return (
+    <div className="flex flex-col min-w-[260px] w-[260px] flex-shrink-0">
+      {/* Column header */}
+      <div className={`flex items-center gap-2 px-3 py-2 rounded-t-lg border ${colors.border} ${colors.bg}`}>
+        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${colors.dot}`} />
+        <span className={`text-sm font-semibold flex-1 ${colors.header}`}>{label}</span>
+        <span className={`text-xs font-medium px-1.5 py-0.5 rounded-full ${colors.bg} ${colors.header} border ${colors.border}`}>
+          {items.length}
+        </span>
+      </div>
+
+      {/* Drop zone */}
+      <div
+        ref={setNodeRef}
+        className={`
+          flex-1 min-h-[200px] rounded-b-lg border-l border-r border-b p-2 space-y-2 transition-colors
+          ${colors.border}
+          ${isOver ? `${colors.bg} border-opacity-100` : "bg-white border-opacity-60"}
+        `}
+      >
+        {items.length === 0 ? (
+          <div
+            className={`
+              flex items-center justify-center h-16 rounded-md border-2 border-dashed
+              ${isOver ? `${colors.border} ${colors.bg}` : "border-gray-200"}
+              text-xs text-gray-400 transition-colors
+            `}
+          >
+            {isOver ? "Drop here" : "No items"}
+          </div>
+        ) : (
+          items.map((item) => (
+            <KanbanCard key={item.id} item={item} workspaceId={workspaceId} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #1

Adds a full Kanban board view to TinyPM, allowing users to visualize and manage work items by status with drag-and-drop.

---

## What was implemented

### New files
- **`src/components/work-items/kanban-board.tsx`** — Main board orchestrating DnD context, columns, and optimistic status updates
- **`src/components/work-items/kanban-column.tsx`** — Droppable column per status with item count badge and hover highlight
- **`src/components/work-items/kanban-card.tsx`** — Draggable card showing type icon, publicId, title, and priority badge
- **`src/app/dashboard/workspaces/[workspaceId]/work-items/kanban/page.tsx`** — Kanban board page with loading skeletons and empty state

### Modified files
- **`src/app/dashboard/workspaces/[workspaceId]/work-items/page.tsx`** — Added "Kanban" toggle button in header
- **`src/app/dashboard/layout.tsx`** — Added Kanban sidebar nav item

---

## Notable decisions

**Library:** `@dnd-kit/core` + `@dnd-kit/utilities`
- Actively maintained, React 18 + Next.js compatible
- Supports both mouse (PointerSensor) and touch (TouchSensor) with activation constraints to prevent accidental drags on scroll

**Columns:** All 6 statuses — To Do, In Progress, In Review, Done, Blocked, Cancelled

**UX:** Optimistic updates with automatic rollback and toast notification on error. Cards show a drag handle to distinguish from the click-to-navigate action.

**Status update:** Uses existing `PATCH /api/workspaces/[workspaceId]/work-items/[itemId]` endpoint — no backend changes required.

---

## Screenshots

Design follows the existing TinyPM design language:
- Same badge colors (blue for In Progress, purple for In Review, green for Done, red for Blocked)
- Same card style (rounded, bordered, white background)
- Horizontal scrolling board for many columns