### PR TITLE
feat: move support link to top nav bar [TD-0019]

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -9,7 +9,6 @@ import { useAuth } from "@/hooks/use-auth"
 
 const navItems = [
   { href: "/dashboard/workspaces", label: "Workspaces", icon: LayoutDashboard },
-  { href: "/dashboard/support", label: "Support", icon: LifeBuoy },
 ]
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -81,6 +80,14 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           </Link>
         )}
         <div className="ml-auto flex items-center gap-4">
+          <Link
+            href="/dashboard/support"
+            className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+            title="Support"
+          >
+            <LifeBuoy className="w-4 h-4" />
+            <span className="hidden sm:inline">Support</span>
+          </Link>
           <span className="text-sm text-gray-600 hidden sm:inline">{user?.email}</span>
           <button onClick={handleSignOut} className="text-sm text-gray-500 hover:text-gray-700">
             <LogOut className="w-4 h-4" />


### PR DESCRIPTION
Closes #3

## Summary

Moves the Support link from the left sidebar (workspaces-only view) into the persistent top nav bar, making it accessible from every page in the dashboard — including inside workspaces.

## Problem

Support was only included in `navItems`, which is only rendered when the user is on the top-level workspaces view. When navigating into a workspace, the sidebar switches to `workspaceNavItems` (Overview, Roadmap, Work Items, etc.), and Support disappears entirely.

## Changes

- **Removed** `Support` from the sidebar `navItems` array
- **Added** a `Support` link with `LifeBuoy` icon to the top `<header>` bar (right side, before user email and logout button)
- The Support link is now part of the shared layout header, so it renders on every authenticated dashboard page

## Before / After

| Before | After |
|--------|-------|
| Support only visible in sidebar on workspaces page | Support visible in top nav bar on all pages |
| Disappears when inside a workspace | Always accessible, icon + label on wider screens |