### PR TITLE
fix: bump message limit to 10,000 chars to match TinyDesk update

### DIFF
--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -5,7 +5,7 @@ const TINYDESK_URL = process.env.TINYDESK_URL || "https://tinydesk.zenithstudio.
 
 const MAX_FILES = 3
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB per file
-const MAX_BODY_LENGTH = 5000
+const MAX_BODY_LENGTH = 10000
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"]
 
 export async function POST(req: Request) {

--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -5,6 +5,7 @@ const TINYDESK_URL = process.env.TINYDESK_URL || "https://tinydesk.zenithstudio.
 
 const MAX_FILES = 3
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB per file
+const MAX_BODY_LENGTH = 5000
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"]
 
 export async function POST(req: Request) {
@@ -22,6 +23,13 @@ export async function POST(req: Request) {
 
   if (!subject?.trim() || !message?.trim()) {
     return NextResponse.json({ error: "Subject and message are required" }, { status: 400 })
+  }
+
+  if (message.length > MAX_BODY_LENGTH) {
+    return NextResponse.json(
+      { error: `Message must be ${MAX_BODY_LENGTH} characters or fewer` },
+      { status: 400 }
+    )
   }
 
   // Collect and validate files
@@ -80,8 +88,9 @@ export async function POST(req: Request) {
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       console.error("TinyDesk ticket creation failed:", res.status, data)
+      const detail = data?.details?.body?.[0]
       return NextResponse.json(
-        { error: "Failed to submit support ticket" },
+        { error: detail || "Failed to submit support ticket" },
         { status: 502 }
       )
     }

--- a/src/app/dashboard/support/page.tsx
+++ b/src/app/dashboard/support/page.tsx
@@ -19,7 +19,7 @@ const categoryOptions = [
 
 const MAX_FILES = 3
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
-const MAX_MESSAGE_LENGTH = 5000
+const MAX_MESSAGE_LENGTH = 10000
 
 export default function SupportPage() {
   const [category, setCategory] = useState("")

--- a/src/app/dashboard/support/page.tsx
+++ b/src/app/dashboard/support/page.tsx
@@ -19,6 +19,7 @@ const categoryOptions = [
 
 const MAX_FILES = 3
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const MAX_MESSAGE_LENGTH = 5000
 
 export default function SupportPage() {
   const [category, setCategory] = useState("")
@@ -136,15 +137,21 @@ export default function SupportPage() {
           placeholder="Brief description of your issue"
         />
 
-        <Textarea
-          id="message"
-          label="Message"
-          required
-          rows={6}
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Describe your issue or question in detail..."
-        />
+        <div>
+          <Textarea
+            id="message"
+            label="Message"
+            required
+            rows={6}
+            maxLength={MAX_MESSAGE_LENGTH}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Describe your issue or question in detail..."
+          />
+          <p className={`text-xs mt-1 text-right ${message.length > MAX_MESSAGE_LENGTH * 0.9 ? "text-red-500" : "text-gray-400"}`}>
+            {message.length}/{MAX_MESSAGE_LENGTH}
+          </p>
+        </div>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
Updates the support ticket message character limit from 5,000 to 10,000 to match TinyDesk's updated limit, so users have more room for detailed descriptions.