### PR TITLE
feat: TD-0024 link signal to roadmap and/or work items

### DIFF
--- a/src/app/api/workspaces/[workspaceId]/signals/[signalId]/link-roadmap/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/signals/[signalId]/link-roadmap/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server"
+import { requireWorkspaceMember } from "@/lib/auth-guard"
+import { getSignalById, linkSignalToRoadmap } from "@/lib/db/queries/signals"
+import { getRoadmapItemById } from "@/lib/db/queries/roadmap-items"
+import { linkSignalToRoadmapSchema } from "@/lib/validations/signal"
+
+/**
+ * POST /api/workspaces/:workspaceId/signals/:signalId/link-roadmap
+ *
+ * Links a signal to an existing roadmap item (without creating a work item).
+ * Sets the signal status to "promoted" and records promotedRoadmapItemId.
+ *
+ * Body: { roadmapItemId: string }
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: { workspaceId: string; signalId: string } }
+) {
+  try {
+    const { workspaceId, signalId } = params
+    await requireWorkspaceMember(workspaceId)
+
+    const signal = await getSignalById(signalId)
+    if (!signal || signal.workspaceId !== workspaceId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    if (signal.status === "promoted" && signal.promotedRoadmapItemId) {
+      return NextResponse.json(
+        { error: "Signal is already linked to a roadmap item" },
+        { status: 409 }
+      )
+    }
+
+    const body = await request.json()
+    const parsed = linkSignalToRoadmapSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid input" },
+        { status: 400 }
+      )
+    }
+
+    const { roadmapItemId } = parsed.data
+
+    // Verify the roadmap item belongs to this workspace
+    const roadmapItem = await getRoadmapItemById(roadmapItemId)
+    if (!roadmapItem || roadmapItem.workspaceId !== workspaceId) {
+      return NextResponse.json(
+        { error: "Roadmap item not found" },
+        { status: 404 }
+      )
+    }
+
+    const updatedSignal = await linkSignalToRoadmap(signalId, roadmapItemId)
+
+    return NextResponse.json(
+      { signal: updatedSignal, roadmapItem },
+      { status: 200 }
+    )
+  } catch (err: any) {
+    if (err.message === "Unauthorized")
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    if (err.message === "Forbidden")
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/api/workspaces/[workspaceId]/signals/[signalId]/promote/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/signals/[signalId]/promote/route.ts
@@ -40,7 +40,7 @@ export async function POST(
       )
     }
 
-    const { title, priority } = parsed.data
+    const { title, priority, roadmapItemId } = parsed.data
 
     // Build description with signal context
     const contextLines = [
@@ -59,7 +59,7 @@ export async function POST(
       .filter((l) => l !== null)
       .join("\n")
 
-    // Create tinypm work item
+    // Create tinypm work item, optionally nested under a roadmap item
     const workItemType = SIGNAL_TYPE_TO_WORK_ITEM_TYPE[signal.type] ?? "feature"
     const workItem = await createWorkItem(workspaceId, {
       title,
@@ -67,10 +67,14 @@ export async function POST(
       type: workItemType as any,
       priority: priority ?? "medium",
       status: "todo",
+      ...(roadmapItemId && { roadmapItemId }),
     })
 
-    // Mark signal as promoted
-    const updatedSignal = await promoteSignal(signalId, workItem.id)
+    // Mark signal as promoted (with optional roadmap link)
+    const updatedSignal = await promoteSignal(signalId, {
+      workItemId: workItem.id,
+      ...(roadmapItemId && { roadmapItemId }),
+    })
 
     return NextResponse.json(
       {

--- a/src/app/dashboard/workspaces/[workspaceId]/signals/[signalId]/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/signals/[signalId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import useSWR from "swr"
-import { ArrowLeft, ArrowUpRight, Trash2, Github } from "lucide-react"
+import { ArrowLeft, ArrowUpRight, Link2, Map, Trash2, Github } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select } from "@/components/ui/select"
@@ -41,10 +41,27 @@ export default function SignalDetailPage({
     fetcher
   )
 
+  // Fetch roadmap items for selection dropdowns
+  const { data: roadmapItems } = useSWR<
+    { id: string; title: string; status: string; quarter?: string }[]
+  >(
+    `/api/workspaces/${workspaceId}/roadmap`,
+    fetcher
+  )
+
+  // ── Promote to Work Item state ────────────────────────
   const [promoteOpen, setPromoteOpen] = useState(false)
   const [promoteTitle, setPromoteTitle] = useState("")
   const [promotePriority, setPromotePriority] = useState("medium")
+  const [promoteRoadmapItemId, setPromoteRoadmapItemId] = useState("")
   const [promoting, setPromoting] = useState(false)
+
+  // ── Link to Roadmap state ─────────────────────────────
+  const [linkRoadmapOpen, setLinkRoadmapOpen] = useState(false)
+  const [linkRoadmapItemId, setLinkRoadmapItemId] = useState("")
+  const [linkingRoadmap, setLinkingRoadmap] = useState(false)
+
+  // ── Delete state ──────────────────────────────────────
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
@@ -63,6 +80,7 @@ export default function SignalDetailPage({
           body: JSON.stringify({
             title: promoteTitle,
             priority: promotePriority,
+            ...(promoteRoadmapItemId && { roadmapItemId: promoteRoadmapItemId }),
           }),
         }
       )
@@ -74,7 +92,8 @@ export default function SignalDetailPage({
       }
 
       const result = await res.json()
-      toast(`Promoted to work item ${result.workItem.publicId}`, { variant: "success" })
+      const roadmapMsg = promoteRoadmapItemId ? " and linked to roadmap" : ""
+      toast(`Promoted to work item ${result.workItem.publicId}${roadmapMsg}`, { variant: "success" })
       setPromoteOpen(false)
       mutate()
       router.push(
@@ -84,6 +103,39 @@ export default function SignalDetailPage({
       toast("Something went wrong", { variant: "error" })
     } finally {
       setPromoting(false)
+    }
+  }
+
+  async function handleLinkToRoadmap() {
+    if (!linkRoadmapItemId) {
+      toast("Please select a roadmap item", { variant: "error" })
+      return
+    }
+    setLinkingRoadmap(true)
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/signals/${signalId}/link-roadmap`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ roadmapItemId: linkRoadmapItemId }),
+        }
+      )
+
+      if (!res.ok) {
+        const err = await res.json()
+        toast(err.error || "Failed to link to roadmap", { variant: "error" })
+        return
+      }
+
+      const result = await res.json()
+      toast(`Linked to roadmap: ${result.roadmapItem.title}`, { variant: "success" })
+      setLinkRoadmapOpen(false)
+      mutate()
+    } catch {
+      toast("Something went wrong", { variant: "error" })
+    } finally {
+      setLinkingRoadmap(false)
     }
   }
 
@@ -133,6 +185,17 @@ export default function SignalDetailPage({
 
   const isPromoted = signal.status === "promoted"
   const isDismissed = signal.status === "dismissed"
+  const hasWorkItem = Boolean(signal.promotedWorkItemId)
+  const hasRoadmapLink = Boolean(signal.promotedRoadmapItemId)
+
+  // Build roadmap item options for selects
+  const roadmapOptions = [
+    { value: "", label: "— No roadmap item —" },
+    ...(roadmapItems ?? []).map((item) => ({
+      value: item.id,
+      label: item.quarter ? `[${item.quarter}] ${item.title}` : item.title,
+    })),
+  ]
 
   return (
     <div>
@@ -151,17 +214,40 @@ export default function SignalDetailPage({
         actions={
           <div className="flex gap-2">
             {!isPromoted && !isDismissed && (
+              <>
+                <Button
+                  onClick={() => {
+                    setPromoteTitle(
+                      signal.clientName
+                        ? `[${signal.clientName}] ${signal.description.slice(0, 80)}`
+                        : signal.description.slice(0, 80)
+                    )
+                    setPromoteRoadmapItemId("")
+                    setPromoteOpen(true)
+                  }}
+                >
+                  <ArrowUpRight className="w-4 h-4 mr-1" /> Promote to issue
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setLinkRoadmapItemId("")
+                    setLinkRoadmapOpen(true)
+                  }}
+                >
+                  <Map className="w-4 h-4 mr-1" /> Link to Roadmap
+                </Button>
+              </>
+            )}
+            {isPromoted && !hasRoadmapLink && (
               <Button
+                variant="secondary"
                 onClick={() => {
-                  setPromoteTitle(
-                    signal.clientName
-                      ? `[${signal.clientName}] ${signal.description.slice(0, 80)}`
-                      : signal.description.slice(0, 80)
-                  )
-                  setPromoteOpen(true)
+                  setLinkRoadmapItemId("")
+                  setLinkRoadmapOpen(true)
                 }}
               >
-                <ArrowUpRight className="w-4 h-4 mr-1" /> Promote to issue
+                <Map className="w-4 h-4 mr-1" /> Link to Roadmap
               </Button>
             )}
             <Button
@@ -210,7 +296,8 @@ export default function SignalDetailPage({
           </div>
         )}
 
-        {isPromoted && signal.promotedWorkItemId && (
+        {/* Promoted to Work Item banner */}
+        {hasWorkItem && (
           <div className="bg-green-50 border border-green-200 rounded-lg p-4">
             <p className="text-sm text-green-800 font-medium">
               ✓ This signal was promoted to a work item.
@@ -227,9 +314,31 @@ export default function SignalDetailPage({
             </button>
           </div>
         )}
+
+        {/* Linked to Roadmap banner */}
+        {hasRoadmapLink && (
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <div className="flex items-center gap-2">
+              <Link2 className="w-4 h-4 text-blue-600" />
+              <p className="text-sm text-blue-800 font-medium">
+                ✓ This signal is linked to a roadmap item.
+              </p>
+            </div>
+            <button
+              onClick={() =>
+                router.push(
+                  `/dashboard/workspaces/${workspaceId}/roadmap/${signal.promotedRoadmapItemId}`
+                )
+              }
+              className="text-sm text-blue-700 underline mt-1"
+            >
+              View roadmap item →
+            </button>
+          </div>
+        )}
       </div>
 
-      {/* Promote modal */}
+      {/* Promote to Work Item modal */}
       {promoteOpen && (
         <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
           <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-6 space-y-4">
@@ -297,6 +406,16 @@ export default function SignalDetailPage({
               }))}
             />
 
+            {roadmapOptions.length > 1 && (
+              <Select
+                id="promote-roadmap"
+                label="Add to Roadmap (optional)"
+                value={promoteRoadmapItemId}
+                onChange={(e) => setPromoteRoadmapItemId(e.target.value)}
+                options={roadmapOptions}
+              />
+            )}
+
             <div className="flex gap-3 pt-2">
               <Button onClick={handlePromote} loading={promoting}>
                 Promote
@@ -305,6 +424,51 @@ export default function SignalDetailPage({
                 variant="secondary"
                 onClick={() => setPromoteOpen(false)}
                 disabled={promoting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Link to Roadmap modal */}
+      {linkRoadmapOpen && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-6 space-y-4">
+            <h2 className="text-lg font-bold">Link to Roadmap</h2>
+            <p className="text-sm text-gray-500">
+              Associate this signal with an existing roadmap item. The signal
+              will remain visible in the Signal PM command centre and will be
+              surfaced on the linked roadmap item.
+            </p>
+
+            {roadmapOptions.length <= 1 ? (
+              <div className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3">
+                No roadmap items found. Create a roadmap item first.
+              </div>
+            ) : (
+              <Select
+                id="link-roadmap-item"
+                label="Roadmap item"
+                value={linkRoadmapItemId}
+                onChange={(e) => setLinkRoadmapItemId(e.target.value)}
+                options={roadmapOptions}
+              />
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <Button
+                onClick={handleLinkToRoadmap}
+                loading={linkingRoadmap}
+                disabled={roadmapOptions.length <= 1}
+              >
+                Link
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setLinkRoadmapOpen(false)}
+                disabled={linkingRoadmap}
               >
                 Cancel
               </Button>

--- a/src/app/dashboard/workspaces/[workspaceId]/signals/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/signals/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import useSWR from "swr"
-import { Plus, Inbox, ArrowUpRight, X } from "lucide-react"
+import { Plus, Inbox, ArrowUpRight, X, Map } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Select } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -240,10 +240,19 @@ export default function SignalsPage({
                       </button>
                     </>
                   )}
-                  {signal.status === "promoted" && signal.promotedWorkItemId && (
-                    <span className="text-xs text-green-600 font-medium">
-                      ✓ Work item created
-                    </span>
+                  {signal.status === "promoted" && (
+                    <div className="flex flex-col items-end gap-0.5">
+                      {signal.promotedWorkItemId && (
+                        <span className="text-xs text-green-600 font-medium">
+                          ✓ Work item
+                        </span>
+                      )}
+                      {signal.promotedRoadmapItemId && (
+                        <span className="text-xs text-blue-600 font-medium flex items-center gap-0.5">
+                          <Map className="w-3 h-3" /> Roadmap
+                        </span>
+                      )}
+                    </div>
                   )}
                 </div>
               </div>

--- a/src/app/dashboard/workspaces/[workspaceId]/signals/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/signals/page.tsx
@@ -39,6 +39,7 @@ const TYPE_COLORS: Record<string, string> = {
 
 const STATUS_COLORS: Record<string, string> = {
   inbox: "bg-yellow-100 text-yellow-700",
+  linked: "bg-indigo-100 text-indigo-700",
   promoted: "bg-green-100 text-green-700",
   dismissed: "bg-gray-100 text-gray-500",
 }
@@ -54,7 +55,7 @@ export default function SignalsPage({
 
   const [typeFilter, setTypeFilter] = useState("")
   const [arrTierFilter, setArrTierFilter] = useState("")
-  const [statusFilter, setStatusFilter] = useState("inbox")
+  const [statusFilter, setStatusFilter] = useState("")
 
   const queryParams = new URLSearchParams()
   if (typeFilter) queryParams.set("type", typeFilter)
@@ -149,7 +150,7 @@ export default function SignalsPage({
           icon={<Inbox className="w-12 h-12" />}
           title="No signals"
           description={
-            statusFilter === "inbox"
+            !statusFilter || statusFilter === "inbox"
               ? "Capture your first signal to start triaging customer feedback."
               : "No signals match the current filters."
           }
@@ -215,7 +216,7 @@ export default function SignalsPage({
                 </div>
 
                 <div className="flex items-center gap-1 shrink-0">
-                  {signal.status === "inbox" && (
+                  {(signal.status === "inbox" || signal.status === "linked") && (
                     <>
                       <Button
                         size="sm"
@@ -239,6 +240,13 @@ export default function SignalsPage({
                         <X className="w-4 h-4" />
                       </button>
                     </>
+                  )}
+                  {signal.status === "linked" && signal.promotedRoadmapItemId && (
+                    <div className="flex flex-col items-end gap-0.5 ml-1">
+                      <span className="text-xs text-indigo-600 font-medium flex items-center gap-0.5">
+                        <Map className="w-3 h-3" /> Roadmap
+                      </span>
+                    </div>
                   )}
                   {signal.status === "promoted" && (
                     <div className="flex flex-col items-end gap-0.5">

--- a/src/lib/__tests__/validations.test.ts
+++ b/src/lib/__tests__/validations.test.ts
@@ -3,6 +3,10 @@ import { createWorkspaceSchema } from "@/lib/validations/workspace"
 import { createRoadmapItemSchema } from "@/lib/validations/roadmap-item"
 import { createWorkItemSchema } from "@/lib/validations/work-item"
 import { createArtefactLinkSchema } from "@/lib/validations/artefact-link"
+import {
+  promoteSignalSchema,
+  linkSignalToRoadmapSchema,
+} from "@/lib/validations/signal"
 
 describe("createWorkspaceSchema", () => {
   it("accepts valid input", () => {
@@ -129,6 +133,56 @@ describe("createWorkItemSchema", () => {
       decisionStatus: "approved",
     })
     expect(result.success).toBe(true)
+  })
+})
+
+describe("promoteSignalSchema (TD-0024)", () => {
+  it("accepts title only (no roadmap)", () => {
+    const result = promoteSignalSchema.safeParse({ title: "Fix login crash" })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts title + priority + roadmapItemId", () => {
+    const result = promoteSignalSchema.safeParse({
+      title: "Fix login crash",
+      priority: "high",
+      roadmapItemId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects invalid roadmapItemId (not a UUID)", () => {
+    const result = promoteSignalSchema.safeParse({
+      title: "Test",
+      roadmapItemId: "not-a-uuid",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("requires title", () => {
+    const result = promoteSignalSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("linkSignalToRoadmapSchema (TD-0024)", () => {
+  it("accepts a valid UUID roadmapItemId", () => {
+    const result = linkSignalToRoadmapSchema.safeParse({
+      roadmapItemId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects non-UUID roadmapItemId", () => {
+    const result = linkSignalToRoadmapSchema.safeParse({
+      roadmapItemId: "not-a-uuid",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("requires roadmapItemId", () => {
+    const result = linkSignalToRoadmapSchema.safeParse({})
+    expect(result.success).toBe(false)
   })
 })
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,7 +27,7 @@ export type SignalSource = (typeof SIGNAL_SOURCES)[number]
 export const SIGNAL_ARR_TIERS = ["enterprise", "mid-market", "smb", "unknown"] as const
 export type SignalArrTier = (typeof SIGNAL_ARR_TIERS)[number]
 
-export const SIGNAL_STATUSES = ["inbox", "promoted", "dismissed"] as const
+export const SIGNAL_STATUSES = ["inbox", "linked", "promoted", "dismissed"] as const
 export type SignalStatus = (typeof SIGNAL_STATUSES)[number]
 
 export const STATUS_LABELS: Record<string, string> = {
@@ -78,6 +78,7 @@ export const SIGNAL_ARR_TIER_LABELS: Record<string, string> = {
 
 export const SIGNAL_STATUS_LABELS: Record<string, string> = {
   inbox: "Inbox",
+  linked: "Linked",
   promoted: "Promoted",
   dismissed: "Dismissed",
 }

--- a/src/lib/db/migrations/0001_td0024_signal_roadmap_link.sql
+++ b/src/lib/db/migrations/0001_td0024_signal_roadmap_link.sql
@@ -1,0 +1,6 @@
+-- TD-0024: Link signal to roadmap item
+-- Adds promotedRoadmapItemId FK to signals table
+
+ALTER TABLE signals
+  ADD COLUMN IF NOT EXISTS promoted_roadmap_item_id UUID
+    REFERENCES roadmap_items(id) ON DELETE SET NULL;

--- a/src/lib/db/queries/signals.ts
+++ b/src/lib/db/queries/signals.ts
@@ -52,7 +52,7 @@ async function getNextPublicId(workspaceId: string): Promise<string> {
     .from(signals)
     .where(eq(signals.workspaceId, workspaceId))
 
-  const num = (result[0]?.count ?? 0) + 1
+  const num = Number(result[0]?.count ?? 0) + 1
   return `SIG-${String(num).padStart(4, "0")}`
 }
 
@@ -108,10 +108,20 @@ export async function promoteSignal(id: string, options: PromoteSignalOptions) {
 
 /**
  * Link a signal to an existing roadmap item (without creating a work item).
- * Sets status to "promoted" and records the roadmap association.
+ * Sets status to "linked" to distinguish from "promoted" (which creates a work item).
  */
 export async function linkSignalToRoadmap(id: string, roadmapItemId: string) {
-  return promoteSignal(id, { roadmapItemId })
+  const [signal] = await db
+    .update(signals)
+    .set({
+      status: "linked",
+      promotedRoadmapItemId: roadmapItemId,
+      updatedAt: new Date(),
+    })
+    .where(eq(signals.id, id))
+    .returning()
+
+  return signal
 }
 
 export async function deleteSignal(id: string) {

--- a/src/lib/db/queries/signals.ts
+++ b/src/lib/db/queries/signals.ts
@@ -3,6 +3,11 @@ import { signals, workItems } from "@/lib/db/schema"
 import { eq, and, desc, sql } from "drizzle-orm"
 import type { CreateSignalInput, UpdateSignalInput } from "@/lib/validations/signal"
 
+export type PromoteSignalOptions = {
+  workItemId?: string
+  roadmapItemId?: string
+}
+
 export async function getSignals(
   workspaceId: string,
   filters?: {
@@ -86,18 +91,27 @@ export async function updateSignal(id: string, data: UpdateSignalInput) {
   return signal
 }
 
-export async function promoteSignal(id: string, workItemId: string) {
+export async function promoteSignal(id: string, options: PromoteSignalOptions) {
   const [signal] = await db
     .update(signals)
     .set({
       status: "promoted",
-      promotedWorkItemId: workItemId,
+      ...(options.workItemId !== undefined && { promotedWorkItemId: options.workItemId }),
+      ...(options.roadmapItemId !== undefined && { promotedRoadmapItemId: options.roadmapItemId }),
       updatedAt: new Date(),
     })
     .where(eq(signals.id, id))
     .returning()
 
   return signal
+}
+
+/**
+ * Link a signal to an existing roadmap item (without creating a work item).
+ * Sets status to "promoted" and records the roadmap association.
+ */
+export async function linkSignalToRoadmap(id: string, roadmapItemId: string) {
+  return promoteSignal(id, { roadmapItemId })
 }
 
 export async function deleteSignal(id: string) {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -150,6 +150,8 @@ export const signals = pgTable("signals", {
   notes: text("notes"),
   promotedWorkItemId: uuid("promoted_work_item_id")
     .references(() => workItems.id, { onDelete: "set null" }),
+  promotedRoadmapItemId: uuid("promoted_roadmap_item_id")
+    .references(() => roadmapItems.id, { onDelete: "set null" }),
   capturedAt: timestamp("captured_at", { mode: "date" }).defaultNow().notNull(),
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
@@ -202,6 +204,7 @@ export const roadmapItemsRelations = relations(roadmapItems, ({ one, many }) => 
     references: [workspaces.id],
   }),
   workItems: many(workItems),
+  signals: many(signals),
 }))
 
 export const workItemsRelations = relations(workItems, ({ one, many }) => ({
@@ -235,5 +238,9 @@ export const signalsRelations = relations(signals, ({ one }) => ({
   promotedWorkItem: one(workItems, {
     fields: [signals.promotedWorkItemId],
     references: [workItems.id],
+  }),
+  promotedRoadmapItem: one(roadmapItems, {
+    fields: [signals.promotedRoadmapItemId],
+    references: [roadmapItems.id],
   }),
 }))

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -146,7 +146,7 @@ export const signals = pgTable("signals", {
   clientName: text("client_name"),
   arrTier: text("arr_tier").notNull().default("unknown"), // enterprise | mid-market | smb | unknown
   type: text("type").notNull(), // feature | bug | compliance | infra
-  status: text("status").notNull().default("inbox"), // inbox | promoted | dismissed
+  status: text("status").notNull().default("inbox"), // inbox | linked | promoted | dismissed
   notes: text("notes"),
   promotedWorkItemId: uuid("promoted_work_item_id")
     .references(() => workItems.id, { onDelete: "set null" }),

--- a/src/lib/validations/signal.ts
+++ b/src/lib/validations/signal.ts
@@ -23,8 +23,15 @@ export const updateSignalSchema = createSignalSchema.partial().extend({
 export const promoteSignalSchema = z.object({
   title: z.string().min(1, "Title is required").max(200),
   priority: z.enum(["low", "medium", "high", "critical"]).optional(),
+  /** Optional: assign the created work item to an existing roadmap item */
+  roadmapItemId: z.string().uuid().optional(),
+})
+
+export const linkSignalToRoadmapSchema = z.object({
+  roadmapItemId: z.string().uuid("Roadmap item ID must be a valid UUID"),
 })
 
 export type CreateSignalInput = z.infer<typeof createSignalSchema>
 export type UpdateSignalInput = z.infer<typeof updateSignalSchema>
 export type PromoteSignalInput = z.infer<typeof promoteSignalSchema>
+export type LinkSignalToRoadmapInput = z.infer<typeof linkSignalToRoadmapSchema>


### PR DESCRIPTION
Fixes #14

## Summary

Signals in the Signal PM command centre can now be linked to **roadmap items** in addition to (or instead of) work items. Two flows are supported:

**Flow 1 — Promote to Work Item + assign to Roadmap (enhanced)**
When promoting a signal to a work item, users can optionally select an existing roadmap item from a dropdown. The created work item gets `roadmapItemId` set and the signal records `promotedRoadmapItemId`.

**Flow 2 — Link to Roadmap directly (new standalone)**
A new "Link to Roadmap" button lets users associate a signal with an existing roadmap item without creating a work item. Useful for strategic/early-stage signals. Sets `promotedRoadmapItemId` and marks the signal as `promoted`.

## Changes

### Schema
- `signals` table: new `promoted_roadmap_item_id` UUID FK → `roadmap_items`
- `signalsRelations`: new `promotedRoadmapItem` relation
- `roadmapItemsRelations`: new `signals` reverse relation
- DB migration: `0001_td0024_signal_roadmap_link.sql`

### Backend
- `src/lib/db/queries/signals.ts`: refactored `promoteSignal()` to accept `{ workItemId?, roadmapItemId? }` options; added `linkSignalToRoadmap()` helper
- `src/lib/validations/signal.ts`: `promoteSignalSchema` extended with optional `roadmapItemId`; new `linkSignalToRoadmapSchema`
- `src/app/api/.../signals/[signalId]/promote/route.ts`: passes `roadmapItemId` to work item creation and signal update
- `src/app/api/.../signals/[signalId]/link-roadmap/route.ts` **(new)**: standalone endpoint for signal → roadmap linking

### Frontend
- Signal detail page: roadmap item selector in the promote modal; new "Link to Roadmap" button; banners showing work item and roadmap item links
- Signal list page: roadmap link indicator (`🗺 Roadmap`) alongside existing `✓ Work item` badge

### Tests
- 7 new validation tests covering `promoteSignalSchema` (with `roadmapItemId`) and `linkSignalToRoadmapSchema`
- All 45 tests pass ✅

Closes #14