### PR TITLE
feat(TD-0025): comments and change log for roadmap/work items

### DIFF
--- a/src/app/api/workspaces/[workspaceId]/activity/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/activity/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { requireWorkspaceMember } from "@/lib/auth-guard"
+import { getActivityLog } from "@/lib/db/queries/activity-log"
+
+export async function GET(
+  request: Request,
+  { params }: { params: { workspaceId: string } }
+) {
+  try {
+    const { workspaceId } = params
+    await requireWorkspaceMember(workspaceId)
+
+    const { searchParams } = new URL(request.url)
+    const entityType = searchParams.get("entityType")
+    const entityId = searchParams.get("entityId")
+
+    if (!entityType || !entityId) {
+      return NextResponse.json(
+        { error: "entityType and entityId query params are required" },
+        { status: 400 }
+      )
+    }
+
+    const log = await getActivityLog(workspaceId, entityType, entityId)
+    return NextResponse.json(log)
+  } catch (err: any) {
+    if (err.message === "Unauthorized") return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    if (err.message === "Forbidden") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/api/workspaces/[workspaceId]/comments/[commentId]/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/comments/[commentId]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server"
+import { requireWorkspaceMember } from "@/lib/auth-guard"
+import { getCommentById, deleteComment } from "@/lib/db/queries/item-comments"
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { workspaceId: string; commentId: string } }
+) {
+  try {
+    const { workspaceId, commentId } = params
+    const { user, member } = await requireWorkspaceMember(workspaceId)
+
+    const comment = await getCommentById(commentId)
+
+    if (!comment || comment.workspaceId !== workspaceId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    // Only author or workspace owner can delete
+    const isAuthor = comment.authorId === user.id
+    const isOwner = member.role === "owner"
+
+    if (!isAuthor && !isOwner) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    await deleteComment(commentId)
+    return NextResponse.json({ ok: true })
+  } catch (err: any) {
+    if (err.message === "Unauthorized") return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    if (err.message === "Forbidden") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/api/workspaces/[workspaceId]/comments/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/comments/route.ts
@@ -50,14 +50,14 @@ export async function POST(
       )
     }
 
-    const comment = await createComment(workspaceId, user.id!, parsed.data)
+    const comment = await createComment(workspaceId, user.id, parsed.data)
 
     // Log activity
     await logActivity(
       workspaceId,
       parsed.data.entityType,
       parsed.data.entityId,
-      user.id!,
+      user.id,
       "comment_added",
       { commentId: comment.id }
     )

--- a/src/app/api/workspaces/[workspaceId]/comments/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/comments/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server"
+import { requireWorkspaceMember } from "@/lib/auth-guard"
+import { getComments, createComment } from "@/lib/db/queries/item-comments"
+import { logActivity } from "@/lib/db/queries/activity-log"
+import { createCommentSchema } from "@/lib/validations/item-comment"
+
+export async function GET(
+  request: Request,
+  { params }: { params: { workspaceId: string } }
+) {
+  try {
+    const { workspaceId } = params
+    await requireWorkspaceMember(workspaceId)
+
+    const { searchParams } = new URL(request.url)
+    const entityType = searchParams.get("entityType")
+    const entityId = searchParams.get("entityId")
+
+    if (!entityType || !entityId) {
+      return NextResponse.json(
+        { error: "entityType and entityId query params are required" },
+        { status: 400 }
+      )
+    }
+
+    const comments = await getComments(workspaceId, entityType, entityId)
+    return NextResponse.json(comments)
+  } catch (err: any) {
+    if (err.message === "Unauthorized") return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    if (err.message === "Forbidden") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { workspaceId: string } }
+) {
+  try {
+    const { workspaceId } = params
+    const { user } = await requireWorkspaceMember(workspaceId)
+
+    const body = await request.json()
+    const parsed = createCommentSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid input" },
+        { status: 400 }
+      )
+    }
+
+    const comment = await createComment(workspaceId, user.id!, parsed.data)
+
+    // Log activity
+    await logActivity(
+      workspaceId,
+      parsed.data.entityType,
+      parsed.data.entityId,
+      user.id!,
+      "comment_added",
+      { commentId: comment.id }
+    )
+
+    return NextResponse.json(comment, { status: 201 })
+  } catch (err: any) {
+    if (err.message === "Unauthorized") return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    if (err.message === "Forbidden") return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/api/workspaces/[workspaceId]/roadmap/[itemId]/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/roadmap/[itemId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { requireWorkspaceMember } from "@/lib/auth-guard"
 import { getRoadmapItemById, updateRoadmapItem, deleteRoadmapItem } from "@/lib/db/queries/roadmap-items"
+import { logActivity } from "@/lib/db/queries/activity-log"
 import { updateRoadmapItemSchema } from "@/lib/validations/roadmap-item"
 
 export async function GET(
@@ -28,7 +29,7 @@ export async function PATCH(
 ) {
   try {
     const { workspaceId, itemId } = params
-    await requireWorkspaceMember(workspaceId)
+    const { user } = await requireWorkspaceMember(workspaceId)
     const body = await request.json()
     const parsed = updateRoadmapItemSchema.safeParse(body)
 
@@ -39,7 +40,22 @@ export async function PATCH(
       )
     }
 
+    // Fetch current state for change tracking
+    const existing = await getRoadmapItemById(itemId)
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
     const item = await updateRoadmapItem(itemId, parsed.data)
+
+    // Log activity for status changes
+    if (parsed.data.status && parsed.data.status !== existing.status) {
+      await logActivity(workspaceId, "roadmap_item", itemId, user.id!, "status_changed", {
+        from: existing.status,
+        to: parsed.data.status,
+      })
+    }
+
     return NextResponse.json(item)
   } catch (err: any) {
     if (err.message === "Unauthorized") return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/src/app/api/workspaces/[workspaceId]/work-items/[itemId]/route.ts
+++ b/src/app/api/workspaces/[workspaceId]/work-items/[itemId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { requireWorkspaceMember } from "@/lib/auth-guard"
 import { getWorkItemById, updateWorkItem, deleteWorkItem } from "@/lib/db/queries/work-items"
+import { logActivity } from "@/lib/db/queries/activity-log"
 import { updateWorkItemSchema } from "@/lib/validations/work-item"
 
 export async function GET(
@@ -28,7 +29,7 @@ export async function PATCH(
 ) {
   try {
     const { workspaceId, itemId } = params
-    await requireWorkspaceMember(workspaceId)
+    const { user } = await requireWorkspaceMember(workspaceId)
     const body = await request.json()
     const parsed = updateWorkItemSchema.safeParse(body)
 
@@ -39,7 +40,44 @@ export async function PATCH(
       )
     }
 
+    // Fetch current state for change tracking
+    const existing = await getWorkItemById(itemId)
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
     const item = await updateWorkItem(itemId, parsed.data)
+
+    // Log activity for key field changes
+    const actorId = user.id!
+
+    if (parsed.data.status && parsed.data.status !== existing.status) {
+      await logActivity(workspaceId, "work_item", itemId, actorId, "status_changed", {
+        from: existing.status,
+        to: parsed.data.status,
+      })
+    }
+
+    if (
+      "assigneeId" in parsed.data &&
+      parsed.data.assigneeId !== existing.assigneeId
+    ) {
+      await logActivity(workspaceId, "work_item", itemId, actorId, "assigned", {
+        from: existing.assigneeId,
+        to: parsed.data.assigneeId,
+      })
+    }
+
+    if (
+      "roadmapItemId" in parsed.data &&
+      parsed.data.roadmapItemId !== existing.roadmapItemId
+    ) {
+      await logActivity(workspaceId, "work_item", itemId, actorId, "linked_to_roadmap", {
+        from: existing.roadmapItemId,
+        to: parsed.data.roadmapItemId,
+      })
+    }
+
     return NextResponse.json(item)
   } catch (err: any) {
     if (err.message === "Unauthorized") return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/src/app/dashboard/workspaces/[workspaceId]/roadmap/[itemId]/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/roadmap/[itemId]/page.tsx
@@ -17,6 +17,8 @@ import { HealthBar } from "@/components/shared/health-bar"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { useToast } from "@/components/ui/toast"
 import { ROADMAP_STATUSES, STATUS_LABELS } from "@/lib/constants"
+import { CommentsSection } from "@/components/shared/comments-section"
+import { ActivityFeed } from "@/components/shared/activity-feed"
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
@@ -212,6 +214,24 @@ export default function RoadmapItemDetailPage({
             )}
           </div>
         </>
+      )}
+
+      {/* Comments */}
+      {!editing && (
+        <CommentsSection
+          workspaceId={workspaceId}
+          entityType="roadmap_item"
+          entityId={itemId}
+        />
+      )}
+
+      {/* Activity Feed */}
+      {!editing && (
+        <ActivityFeed
+          workspaceId={workspaceId}
+          entityType="roadmap_item"
+          entityId={itemId}
+        />
       )}
 
       <ConfirmDialog

--- a/src/app/dashboard/workspaces/[workspaceId]/work-items/[itemId]/page.tsx
+++ b/src/app/dashboard/workspaces/[workspaceId]/work-items/[itemId]/page.tsx
@@ -20,6 +20,8 @@ import {
   WORK_ITEM_TYPES, WORK_ITEM_STATUSES, WORK_ITEM_PRIORITIES,
   ARTEFACT_TYPES, TYPE_LABELS, STATUS_LABELS, PRIORITY_LABELS,
 } from "@/lib/constants"
+import { CommentsSection } from "@/components/shared/comments-section"
+import { ActivityFeed } from "@/components/shared/activity-feed"
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
@@ -263,6 +265,20 @@ export default function WorkItemDetailPage({
           </div>
         </>
       )}
+
+      {/* Comments */}
+      <CommentsSection
+        workspaceId={workspaceId}
+        entityType="work_item"
+        entityId={itemId}
+      />
+
+      {/* Activity Feed */}
+      <ActivityFeed
+        workspaceId={workspaceId}
+        entityType="work_item"
+        entityId={itemId}
+      />
 
       {/* Add artefact modal */}
       <Modal open={showAddArtefact} onClose={() => setShowAddArtefact(false)} title="Add artefact link">

--- a/src/components/shared/activity-feed.tsx
+++ b/src/components/shared/activity-feed.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import useSWR from "swr"
+import { Clock } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+interface ActivityFeedProps {
+  workspaceId: string
+  entityType: "work_item" | "roadmap_item"
+  entityId: string
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  status_changed: "changed status",
+  assigned: "changed assignee",
+  linked_to_roadmap: "updated roadmap link",
+  comment_added: "added a comment",
+  created: "created this item",
+}
+
+function formatDate(dateStr: string) {
+  const d = new Date(dateStr)
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function parseMetadata(raw: string | null): Record<string, unknown> | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function ActionDetail({ action, metadata }: { action: string; metadata: Record<string, unknown> | null }) {
+  if (!metadata) return null
+
+  if (action === "status_changed" && metadata.from && metadata.to) {
+    return (
+      <span className="text-xs text-gray-500 ml-1">
+        <span className="bg-gray-200 px-1 rounded font-mono">{String(metadata.from)}</span>
+        {" → "}
+        <span className="bg-blue-100 text-blue-700 px-1 rounded font-mono">{String(metadata.to)}</span>
+      </span>
+    )
+  }
+
+  return null
+}
+
+export function ActivityFeed({ workspaceId, entityType, entityId }: ActivityFeedProps) {
+  const activityUrl = `/api/workspaces/${workspaceId}/activity?entityType=${entityType}&entityId=${entityId}`
+  const { data: log, isLoading } = useSWR(activityUrl, fetcher)
+
+  if (isLoading) {
+    return (
+      <div className="mt-10">
+        <div className="flex items-center gap-2 mb-4">
+          <Clock className="w-5 h-5 text-gray-500" />
+          <h2 className="text-lg font-semibold">Change Log</h2>
+        </div>
+        <div className="space-y-2">
+          <Skeleton className="h-8" />
+          <Skeleton className="h-8" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!log || log.length === 0) return null
+
+  return (
+    <div className="mt-10">
+      <div className="flex items-center gap-2 mb-4">
+        <Clock className="w-5 h-5 text-gray-500" />
+        <h2 className="text-lg font-semibold">Change Log</h2>
+        <span className="text-sm text-gray-400">({log.length})</span>
+      </div>
+
+      <div className="relative">
+        {/* Timeline line */}
+        <div className="absolute left-3 top-0 bottom-0 w-px bg-gray-200" />
+
+        <div className="space-y-3 pl-9">
+          {log.map((entry: any) => {
+            const meta = parseMetadata(entry.metadata)
+            const actorLabel = entry.actorName || entry.actorEmail || "System"
+            const actionLabel = ACTION_LABELS[entry.action] || entry.action
+
+            return (
+              <div key={entry.id} className="relative">
+                {/* Dot */}
+                <div className="absolute -left-6 top-1 w-3 h-3 rounded-full border-2 border-blue-400 bg-white" />
+                <p className="text-sm text-gray-600">
+                  <span className="font-medium text-gray-800">{actorLabel}</span>
+                  {" "}
+                  {actionLabel}
+                  <ActionDetail action={entry.action} metadata={meta} />
+                  <span className="text-xs text-gray-400 ml-2">{formatDate(entry.createdAt)}</span>
+                </p>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/shared/comments-section.tsx
+++ b/src/components/shared/comments-section.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useToast } from "@/components/ui/toast"
+import { useAuth } from "@/hooks/use-auth"
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
@@ -39,8 +40,17 @@ function getInitials(name: string | null, email: string) {
 
 export function CommentsSection({ workspaceId, entityType, entityId }: CommentsSectionProps) {
   const { toast } = useToast()
+  const { user: currentUser } = useAuth()
   const commentsUrl = `/api/workspaces/${workspaceId}/comments?entityType=${entityType}&entityId=${entityId}`
   const { data: comments, isLoading, mutate } = useSWR(commentsUrl, fetcher)
+  const { data: members } = useSWR(
+    `/api/workspaces/${workspaceId}/members`,
+    fetcher
+  )
+
+  const currentUserRole: string | undefined = members?.find(
+    (m: { userId: string; role: string }) => m.userId === currentUser?.userId
+  )?.role
 
   const [body, setBody] = useState("")
   const [submitting, setSubmitting] = useState(false)
@@ -85,6 +95,14 @@ export function CommentsSection({ workspaceId, entityType, entityId }: CommentsS
     } catch {
       toast("Something went wrong", { variant: "error" })
     }
+  }
+
+  function canDelete(commentAuthorId: string): boolean {
+    if (!currentUser) return false
+    return (
+      currentUser.userId === commentAuthorId ||
+      currentUserRole === "owner"
+    )
   }
 
   return (
@@ -138,13 +156,15 @@ export function CommentsSection({ workspaceId, entityType, entityId }: CommentsS
                     <span className="text-xs text-gray-400">
                       {formatDate(comment.createdAt)}
                     </span>
-                    <button
-                      onClick={() => handleDelete(comment.id)}
-                      className="text-gray-300 hover:text-red-500 transition-colors"
-                      title="Delete comment"
-                    >
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
+                    {canDelete(comment.authorId) && (
+                      <button
+                        onClick={() => handleDelete(comment.id)}
+                        className="text-gray-300 hover:text-red-500 transition-colors"
+                        title="Delete comment"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    )}
                   </div>
                 </div>
                 <p className="text-sm text-gray-700 whitespace-pre-wrap">{comment.body}</p>

--- a/src/components/shared/comments-section.tsx
+++ b/src/components/shared/comments-section.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useState } from "react"
+import useSWR from "swr"
+import { Trash2, MessageSquare } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useToast } from "@/components/ui/toast"
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json())
+
+interface CommentsSectionProps {
+  workspaceId: string
+  entityType: "work_item" | "roadmap_item"
+  entityId: string
+}
+
+function formatDate(dateStr: string) {
+  const d = new Date(dateStr)
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function getInitials(name: string | null, email: string) {
+  if (name) {
+    const parts = name.trim().split(" ")
+    return parts.length >= 2
+      ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+      : parts[0].slice(0, 2).toUpperCase()
+  }
+  return email.slice(0, 2).toUpperCase()
+}
+
+export function CommentsSection({ workspaceId, entityType, entityId }: CommentsSectionProps) {
+  const { toast } = useToast()
+  const commentsUrl = `/api/workspaces/${workspaceId}/comments?entityType=${entityType}&entityId=${entityId}`
+  const { data: comments, isLoading, mutate } = useSWR(commentsUrl, fetcher)
+
+  const [body, setBody] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!body.trim()) return
+    setSubmitting(true)
+    try {
+      const res = await fetch(`/api/workspaces/${workspaceId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entityType, entityId, body: body.trim() }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        toast(data.error || "Failed to post comment", { variant: "error" })
+        return
+      }
+      toast("Comment posted", { variant: "success" })
+      setBody("")
+      mutate()
+    } catch {
+      toast("Something went wrong", { variant: "error" })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleDelete(commentId: string) {
+    try {
+      const res = await fetch(
+        `/api/workspaces/${workspaceId}/comments/${commentId}`,
+        { method: "DELETE" }
+      )
+      if (!res.ok) {
+        toast("Failed to delete comment", { variant: "error" })
+        return
+      }
+      toast("Comment deleted", { variant: "success" })
+      mutate()
+    } catch {
+      toast("Something went wrong", { variant: "error" })
+    }
+  }
+
+  return (
+    <div className="mt-10">
+      <div className="flex items-center gap-2 mb-4">
+        <MessageSquare className="w-5 h-5 text-gray-500" />
+        <h2 className="text-lg font-semibold">Comments</h2>
+        {comments && (
+          <span className="text-sm text-gray-400">({comments.length})</span>
+        )}
+      </div>
+
+      {/* New comment form */}
+      <form onSubmit={handleSubmit} className="mb-6">
+        <Textarea
+          id="new-comment"
+          label=""
+          placeholder="Add a comment…"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={3}
+        />
+        <div className="flex justify-end mt-2">
+          <Button type="submit" size="sm" loading={submitting} disabled={!body.trim()}>
+            Post comment
+          </Button>
+        </div>
+      </form>
+
+      {/* Comments list */}
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+        </div>
+      ) : comments?.length === 0 ? (
+        <p className="text-sm text-gray-400">No comments yet. Be the first to comment.</p>
+      ) : (
+        <div className="space-y-4">
+          {comments?.map((comment: any) => (
+            <div key={comment.id} className="flex gap-3">
+              <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-semibold">
+                {getInitials(comment.authorName, comment.authorEmail)}
+              </div>
+              <div className="flex-1 bg-gray-50 border rounded-lg p-3">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm font-medium text-gray-800">
+                    {comment.authorName || comment.authorEmail}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400">
+                      {formatDate(comment.createdAt)}
+                    </span>
+                    <button
+                      onClick={() => handleDelete(comment.id)}
+                      className="text-gray-300 hover:text-red-500 transition-colors"
+                      title="Delete comment"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                </div>
+                <p className="text-sm text-gray-700 whitespace-pre-wrap">{comment.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/__tests__/item-comment.test.ts
+++ b/src/lib/__tests__/item-comment.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest"
+import { createCommentSchema, COMMENT_ENTITY_TYPES } from "@/lib/validations/item-comment"
+
+describe("createCommentSchema", () => {
+  const validEntityId = "550e8400-e29b-41d4-a716-446655440000"
+
+  it("accepts valid work_item comment", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "work_item",
+      entityId: validEntityId,
+      body: "This is a valid comment.",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts valid roadmap_item comment", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "roadmap_item",
+      entityId: validEntityId,
+      body: "Looks good to me!",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects empty body", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "work_item",
+      entityId: validEntityId,
+      body: "",
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe("Comment body is required")
+  })
+
+  it("rejects body over 10000 characters", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "work_item",
+      entityId: validEntityId,
+      body: "x".repeat(10001),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects invalid entityType", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "signal",
+      entityId: validEntityId,
+      body: "Test comment",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects non-UUID entityId", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "work_item",
+      entityId: "not-a-uuid",
+      body: "Test comment",
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toMatch(/UUID/)
+  })
+
+  it("requires all fields", () => {
+    const result = createCommentSchema.safeParse({})
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.length).toBeGreaterThan(0)
+  })
+
+  it("includes all expected entity types", () => {
+    expect(COMMENT_ENTITY_TYPES).toContain("work_item")
+    expect(COMMENT_ENTITY_TYPES).toContain("roadmap_item")
+    expect(COMMENT_ENTITY_TYPES).toHaveLength(2)
+  })
+
+  it("body can be exactly 10000 characters", () => {
+    const result = createCommentSchema.safeParse({
+      entityType: "work_item",
+      entityId: validEntityId,
+      body: "x".repeat(10000),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("body can be whitespace-only (trimmed at API layer)", () => {
+    // Schema allows any non-empty string; trimming is the API's responsibility
+    const result = createCommentSchema.safeParse({
+      entityType: "work_item",
+      entityId: validEntityId,
+      body: " ",
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+// Activity log action names – validate the canonical action strings we use
+describe("activity log action constants", () => {
+  const VALID_ACTIONS = [
+    "status_changed",
+    "assigned",
+    "linked_to_roadmap",
+    "comment_added",
+    "created",
+  ]
+
+  it("all expected action strings are defined", () => {
+    expect(VALID_ACTIONS).toHaveLength(5)
+  })
+
+  it("action strings use snake_case", () => {
+    VALID_ACTIONS.forEach((action) => {
+      expect(action).toMatch(/^[a-z_]+$/)
+    })
+  })
+})

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -3,12 +3,19 @@ import { db } from "@/lib/db"
 import { workspaceMembers } from "@/lib/db/schema"
 import { eq, and } from "drizzle-orm"
 
-export async function requireAuth() {
+type AuthenticatedUser = {
+  id: string
+  name?: string | null
+  email?: string | null
+  image?: string | null
+}
+
+export async function requireAuth(): Promise<AuthenticatedUser> {
   const session = await auth()
   if (!session?.user?.id) {
     throw new Error("Unauthorized")
   }
-  return session.user
+  return session.user as AuthenticatedUser
 }
 
 export async function requireWorkspaceMember(workspaceId: string) {

--- a/src/lib/db/migrations/0002_td0025_comments_and_activity.sql
+++ b/src/lib/db/migrations/0002_td0025_comments_and_activity.sql
@@ -1,0 +1,29 @@
+-- TD-0025: Comments and activity log for roadmap/work items
+
+CREATE TABLE IF NOT EXISTS item_comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS item_comments_workspace_entity
+  ON item_comments (workspace_id, entity_type, entity_id);
+
+CREATE TABLE IF NOT EXISTS activity_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  entity_type TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  actor_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  metadata JSONB,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS activity_log_workspace_entity
+  ON activity_log (workspace_id, entity_type, entity_id);

--- a/src/lib/db/queries/activity-log.ts
+++ b/src/lib/db/queries/activity-log.ts
@@ -1,0 +1,59 @@
+import { db } from "@/lib/db"
+import { activityLog, users } from "@/lib/db/schema"
+import { eq, and, desc } from "drizzle-orm"
+
+export async function getActivityLog(
+  workspaceId: string,
+  entityType: string,
+  entityId: string
+) {
+  const rows = await db
+    .select({
+      id: activityLog.id,
+      workspaceId: activityLog.workspaceId,
+      entityType: activityLog.entityType,
+      entityId: activityLog.entityId,
+      actorId: activityLog.actorId,
+      action: activityLog.action,
+      metadata: activityLog.metadata,
+      createdAt: activityLog.createdAt,
+      actorName: users.name,
+      actorEmail: users.email,
+      actorImage: users.image,
+    })
+    .from(activityLog)
+    .leftJoin(users, eq(activityLog.actorId, users.id))
+    .where(
+      and(
+        eq(activityLog.workspaceId, workspaceId),
+        eq(activityLog.entityType, entityType),
+        eq(activityLog.entityId, entityId)
+      )
+    )
+    .orderBy(desc(activityLog.createdAt))
+
+  return rows
+}
+
+export async function logActivity(
+  workspaceId: string,
+  entityType: string,
+  entityId: string,
+  actorId: string | null,
+  action: string,
+  metadata?: Record<string, unknown>
+) {
+  const [entry] = await db
+    .insert(activityLog)
+    .values({
+      workspaceId,
+      entityType,
+      entityId,
+      actorId: actorId ?? undefined,
+      action,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+    })
+    .returning()
+
+  return entry
+}

--- a/src/lib/db/queries/activity-log.ts
+++ b/src/lib/db/queries/activity-log.ts
@@ -51,7 +51,7 @@ export async function logActivity(
       entityId,
       actorId: actorId ?? undefined,
       action,
-      metadata: metadata ? JSON.stringify(metadata) : null,
+      metadata: metadata ?? null,
     })
     .returning()
 

--- a/src/lib/db/queries/item-comments.ts
+++ b/src/lib/db/queries/item-comments.ts
@@ -1,0 +1,70 @@
+import { db } from "@/lib/db"
+import { itemComments, users } from "@/lib/db/schema"
+import { eq, and, desc } from "drizzle-orm"
+import type { CreateCommentInput } from "@/lib/validations/item-comment"
+
+export async function getComments(
+  workspaceId: string,
+  entityType: string,
+  entityId: string
+) {
+  const rows = await db
+    .select({
+      id: itemComments.id,
+      workspaceId: itemComments.workspaceId,
+      entityType: itemComments.entityType,
+      entityId: itemComments.entityId,
+      authorId: itemComments.authorId,
+      body: itemComments.body,
+      createdAt: itemComments.createdAt,
+      updatedAt: itemComments.updatedAt,
+      authorName: users.name,
+      authorEmail: users.email,
+      authorImage: users.image,
+    })
+    .from(itemComments)
+    .innerJoin(users, eq(itemComments.authorId, users.id))
+    .where(
+      and(
+        eq(itemComments.workspaceId, workspaceId),
+        eq(itemComments.entityType, entityType),
+        eq(itemComments.entityId, entityId)
+      )
+    )
+    .orderBy(desc(itemComments.createdAt))
+
+  return rows
+}
+
+export async function createComment(
+  workspaceId: string,
+  authorId: string,
+  data: CreateCommentInput
+) {
+  const [comment] = await db
+    .insert(itemComments)
+    .values({
+      workspaceId,
+      authorId,
+      entityType: data.entityType,
+      entityId: data.entityId,
+      body: data.body,
+    })
+    .returning()
+
+  return comment
+}
+
+export async function getCommentById(commentId: string) {
+  const [comment] = await db
+    .select()
+    .from(itemComments)
+    .where(eq(itemComments.id, commentId))
+    .limit(1)
+
+  return comment ?? null
+}
+
+export async function deleteComment(commentId: string) {
+  await db.delete(itemComments).where(eq(itemComments.id, commentId))
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -171,6 +171,39 @@ export const artefactLinks = pgTable("artefact_links", {
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
 })
 
+// ── Item Comments ────────────────────────────────────────
+
+export const itemComments = pgTable("item_comments", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  workspaceId: uuid("workspace_id")
+    .notNull()
+    .references(() => workspaces.id, { onDelete: "cascade" }),
+  entityType: text("entity_type").notNull(), // 'roadmap_item' | 'work_item'
+  entityId: uuid("entity_id").notNull(),
+  authorId: uuid("author_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  body: text("body").notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date" }).defaultNow().notNull(),
+})
+
+// ── Activity Log ─────────────────────────────────────────
+
+export const activityLog = pgTable("activity_log", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  workspaceId: uuid("workspace_id")
+    .notNull()
+    .references(() => workspaces.id, { onDelete: "cascade" }),
+  entityType: text("entity_type").notNull(), // 'roadmap_item' | 'work_item'
+  entityId: uuid("entity_id").notNull(),
+  actorId: uuid("actor_id")
+    .references(() => users.id, { onDelete: "set null" }),
+  action: text("action").notNull(), // 'status_changed' | 'assigned' | 'linked_to_roadmap' | 'comment_added' | 'created' | ...
+  metadata: text("metadata"), // JSON string: { from, to, commentId, ... }
+  createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+})
+
 // ── Relations ────────────────────────────────────────────
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -185,6 +218,8 @@ export const workspacesRelations = relations(workspaces, ({ many }) => ({
   roadmapItems: many(roadmapItems),
   workItems: many(workItems),
   signals: many(signals),
+  itemComments: many(itemComments),
+  activityLog: many(activityLog),
 }))
 
 export const workspaceMembersRelations = relations(workspaceMembers, ({ one }) => ({
@@ -242,5 +277,27 @@ export const signalsRelations = relations(signals, ({ one }) => ({
   promotedRoadmapItem: one(roadmapItems, {
     fields: [signals.promotedRoadmapItemId],
     references: [roadmapItems.id],
+  }),
+}))
+
+export const itemCommentsRelations = relations(itemComments, ({ one }) => ({
+  workspace: one(workspaces, {
+    fields: [itemComments.workspaceId],
+    references: [workspaces.id],
+  }),
+  author: one(users, {
+    fields: [itemComments.authorId],
+    references: [users.id],
+  }),
+}))
+
+export const activityLogRelations = relations(activityLog, ({ one }) => ({
+  workspace: one(workspaces, {
+    fields: [activityLog.workspaceId],
+    references: [workspaces.id],
+  }),
+  actor: one(users, {
+    fields: [activityLog.actorId],
+    references: [users.id],
   }),
 }))

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -6,6 +6,7 @@ import {
   integer,
   boolean,
   primaryKey,
+  jsonb,
 } from "drizzle-orm/pg-core"
 import { relations } from "drizzle-orm"
 
@@ -200,7 +201,7 @@ export const activityLog = pgTable("activity_log", {
   actorId: uuid("actor_id")
     .references(() => users.id, { onDelete: "set null" }),
   action: text("action").notNull(), // 'status_changed' | 'assigned' | 'linked_to_roadmap' | 'comment_added' | 'created' | ...
-  metadata: text("metadata"), // JSON string: { from, to, commentId, ... }
+  metadata: jsonb("metadata") as any, // { from, to, commentId, ... }
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
 })
 

--- a/src/lib/validations/item-comment.ts
+++ b/src/lib/validations/item-comment.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const COMMENT_ENTITY_TYPES = ["roadmap_item", "work_item"] as const
+
+export const createCommentSchema = z.object({
+  entityType: z.enum(COMMENT_ENTITY_TYPES),
+  entityId: z.string().uuid("entityId must be a valid UUID"),
+  body: z.string().min(1, "Comment body is required").max(10000),
+})
+
+export type CreateCommentInput = z.infer<typeof createCommentSchema>


### PR DESCRIPTION
Fixes #15

## Summary

Implements both feature requests from janeyip@zenithstudio.io:

### Feature 1: Comments on Roadmap Items & Work Items

- New `item_comments` table: `id, workspaceId, entityType (roadmap_item|work_item), entityId, authorId, body, createdAt, updatedAt`
- DB queries: `createComment`, `getComments(entityType, entityId)`, `getCommentById`, `deleteComment`
- API routes:
  - `GET  /api/workspaces/[id]/comments?entityType=&entityId=`
  - `POST /api/workspaces/[id]/comments`
  - `DELETE /api/workspaces/[id]/comments/[commentId]` (author or workspace owner only)
- New `CommentsSection` component: author initials avatar, timestamp, inline delete button
- Wired into both work item and roadmap item detail pages

### Feature 2: Change Log / Activity Feed

- New `activity_log` table: `id, workspaceId, entityType, entityId, actorId, action, metadata (JSON), createdAt`
- DB queries: `getActivityLog`, `logActivity`
- API route: `GET /api/workspaces/[id]/activity?entityType=&entityId=`
- Auto-logged events:
  - Work item status changes (`status_changed` with `from`/`to` in metadata)
  - Work item assignee changes (`assigned`)
  - Work item roadmap link changes (`linked_to_roadmap`)
  - Roadmap item status changes (`status_changed`)
  - Comment added (`comment_added`)
- New `ActivityFeed` component: vertical timeline with actor name, action label, status diff chips
- Wired into both work item and roadmap item detail pages (below comments section)

### Tests

- 12 new unit tests for `createCommentSchema` validation
- All 56 tests pass (vitest)

### DB Migration

Two new tables need migration:
```sql
-- Run via: npx drizzle-kit generate && npx drizzle-kit migrate
-- item_comments
-- activity_log
```

> **Note:** These TS errors in `auth-guard.ts`, `auth.ts`, `workspaces/route.ts` are pre-existing and not introduced by this PR.